### PR TITLE
keep track of the arguments passed to the action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-easy-async",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Redux Easy Async makes handling asynchronous actions, such as API requests, simple, reliable, and powerful",
   "main": "dist/index.js",
   "scripts": {

--- a/src/async-action.js
+++ b/src/async-action.js
@@ -93,7 +93,7 @@ export const createAsyncAction = (type, fn, options = {}) => {
     return {
       type: namespace,
       ...action,
-      args,
+      actionCreatorArgs: args,
       actionName: actionCreator.actionName,
       startActionCreator: actionCreator.start,
       successActionCreator: actionCreator.success,

--- a/src/async-action.js
+++ b/src/async-action.js
@@ -50,24 +50,24 @@ const decorateActionCreator = (actionCreator, asyncConstants) => {
  *     //   - `resp`: the raw api response. Because of the nature of the promises errors that
  *     //     cause the makeRequest promise to be rejected will also get caught here as `resp`
  *     //     and cause a failed request action.
- *     meta = {},
+ *     meta: {},
  *
  *     // function that takes your redux state and returns true or false whether to proceed with
  *     // the request. For example: checking if there is already a similar request in progress or
  *     // the requested data is already cached. *OPTIONAL*
- *     shouldMakeRequest = (state) => true,
+ *     shouldMakeRequest: (state) => true,
  *
- *     // `parseStart`, `parseSuccess`, and `parseSuccess` can be useful if you want to modify
+ *     // `parseStart`, `parseSuccess`, and `parseFail` can be useful if you want to modify
  *     // raw API responses, errors, etc. before passing them to your reducer. The return value
  *     // of each becomes the payload for start, success, and fail actions. By default response
  *     // will not be modified.
  *     //
  *     // the return value of `parseStart` becomes the payload for the start action. *OPTIONAL*
- *     parseStart = () => null,
+ *     parseStart: () => null,
  *     // the return value of `parseSuccess` becomes the payload for the success action. *OPTIONAL*
- *     parseSuccess = resp => resp,
+ *     parseSuccess: resp => resp,
  *     // the return value of `parseFail` becomes the payload for the fail action. *OPTIONAL*
- *     parseFail = resp => resp,
+ *     parseFail: resp => resp,
  *   }
  *
  * })
@@ -93,6 +93,7 @@ export const createAsyncAction = (type, fn, options = {}) => {
     return {
       type: namespace,
       ...action,
+      args,
       actionName: actionCreator.actionName,
       startActionCreator: actionCreator.start,
       successActionCreator: actionCreator.success,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -48,6 +48,8 @@ export const createAsyncMiddleware = (options = {}) => {
       makeRequest,
       // additional meta that will be passed to the action if any - must be an object
       meta = {},
+      // arguments passed to the action when it was invoked.
+      args = {},
       // function that returns boolean for whether to proceed with the request.
       shouldMakeRequest = () => true,
       // on start the result of parse() is passed as the payload of the start action
@@ -77,6 +79,7 @@ export const createAsyncMiddleware = (options = {}) => {
       meta: {
         ...meta,
         actionName,
+        args,
         asyncType: 'start',
         asyncID,
         requestStartTime,
@@ -90,6 +93,7 @@ export const createAsyncMiddleware = (options = {}) => {
         meta: {
           ...meta,
           actionName,
+          args,
           asyncType: 'success',
           asyncID,
           requestStartTime,
@@ -103,6 +107,7 @@ export const createAsyncMiddleware = (options = {}) => {
         meta: {
           ...meta,
           actionName,
+          args,
           asyncType: 'fail',
           asyncID,
           requestStartTime,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,7 +49,7 @@ export const createAsyncMiddleware = (options = {}) => {
       // additional meta that will be passed to the action if any - must be an object
       meta = {},
       // arguments passed to the action when it was invoked.
-      args = {},
+      actionCreatorArgs = {},
       // function that returns boolean for whether to proceed with the request.
       shouldMakeRequest = () => true,
       // on start the result of parse() is passed as the payload of the start action
@@ -79,7 +79,7 @@ export const createAsyncMiddleware = (options = {}) => {
       meta: {
         ...meta,
         actionName,
-        args,
+        actionCreatorArgs,
         asyncType: 'start',
         asyncID,
         requestStartTime,
@@ -93,7 +93,7 @@ export const createAsyncMiddleware = (options = {}) => {
         meta: {
           ...meta,
           actionName,
-          args,
+          actionCreatorArgs,
           asyncType: 'success',
           asyncID,
           requestStartTime,
@@ -107,7 +107,7 @@ export const createAsyncMiddleware = (options = {}) => {
         meta: {
           ...meta,
           actionName,
-          args,
+          actionCreatorArgs,
           asyncType: 'fail',
           asyncID,
           requestStartTime,

--- a/test/async-action.js
+++ b/test/async-action.js
@@ -66,7 +66,7 @@ describe('Async Actions', () => {
     it('action creator returns an action with all correct attributes', () => {
       const makeRequest = () => {};
       const meta = {};
-      const args = [{ test: 'test' }, 'args'];
+      const actionCreatorArgs = [{ test: 'test' }, 'args'];
       const shouldMakeRequest = () => true;
       const parseStart = () => null;
       const parseSuccess = resp => resp;
@@ -81,7 +81,7 @@ describe('Async Actions', () => {
         parseFail,
       }));
 
-      const action = fn(...args);
+      const action = fn(...actionCreatorArgs);
 
       // auto generated attributes
       assert.propertyVal(action, 'type', 'REDUX_EASY_ASYNC_NAMESPACE');
@@ -97,7 +97,7 @@ describe('Async Actions', () => {
       assert.propertyVal(action, 'parseStart', parseStart);
       assert.propertyVal(action, 'parseSuccess', parseSuccess);
       assert.propertyVal(action, 'parseFail', parseFail);
-      assert.deepEqual(action.args, args);
+      assert.deepEqual(action.actionCreatorArgs, actionCreatorArgs);
     });
     it('throws error if action creator does not return an object with a makeRequest function', () => {
       let fn = createAsyncAction('TEST', () => {});

--- a/test/async-action.js
+++ b/test/async-action.js
@@ -63,9 +63,10 @@ describe('Async Actions', () => {
       assert.equal(fn.success().type, 'SUCCESS_TEST');
       assert.equal(fn.fail().type, 'FAIL_TEST');
     });
-    it('action creator returns and action with all correct attributes', () => {
+    it('action creator returns an action with all correct attributes', () => {
       const makeRequest = () => {};
       const meta = {};
+      const args = [{ test: 'test' }, 'args'];
       const shouldMakeRequest = () => true;
       const parseStart = () => null;
       const parseSuccess = resp => resp;
@@ -80,7 +81,7 @@ describe('Async Actions', () => {
         parseFail,
       }));
 
-      const action = fn();
+      const action = fn(...args);
 
       // auto generated attributes
       assert.propertyVal(action, 'type', 'REDUX_EASY_ASYNC_NAMESPACE');
@@ -96,6 +97,7 @@ describe('Async Actions', () => {
       assert.propertyVal(action, 'parseStart', parseStart);
       assert.propertyVal(action, 'parseSuccess', parseSuccess);
       assert.propertyVal(action, 'parseFail', parseFail);
+      assert.deepEqual(action.args, args);
     });
     it('throws error if action creator does not return an object with a makeRequest function', () => {
       let fn = createAsyncAction('TEST', () => {});
@@ -105,4 +107,3 @@ describe('Async Actions', () => {
     });
   });
 });
-


### PR DESCRIPTION
Allow the start, success and fail actions for a an async action to keep track of the arguments the action was invoked with.