### PR TITLE
Don't store actionCreatorArgs in the requests reducer meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-easy-async",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Redux Easy Async makes handling asynchronous actions, such as API requests, simple, reliable, and powerful",
   "main": "dist/index.js",
   "scripts": {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -25,7 +25,7 @@ const createSingleAsyncReducer = (type) => {
       if (action.type === START_TYPE) {
         updatedPendingRequests = [
           ...state.pendingRequests,
-          // store the meta but omit `actionCreatorArgs` as they may not be serializable
+          // store the meta but omit `actionCreatorArgs` as they may be large or not serializable
           _.omit(action.meta, 'actionCreatorArgs'),
         ];
       } else {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux';
+import _ from 'lodash';
 import { getOrCreateAsyncConstants } from './async-constants';
 import {
   ERRORS,
@@ -22,7 +23,11 @@ const createSingleAsyncReducer = (type) => {
       let updatedPendingRequests;
 
       if (action.type === START_TYPE) {
-        updatedPendingRequests = [...state.pendingRequests, action.meta];
+        updatedPendingRequests = [
+          ...state.pendingRequests,
+          // store the meta but omit `actionCreatorArgs` as they may not be serializable
+          _.omit(action.meta, 'actionCreatorArgs'),
+        ];
       } else {
         updatedPendingRequests = state.pendingRequests.filter(req => (
           req.asyncID !== action.meta.asyncID


### PR DESCRIPTION
The previous PR (https://github.com/evanhobbs/redux-easy-async/pull/3) caused arguments to the action creator function to be stored in the requests reducer as `meta.actionCreatorArgs`. This can cause problems when the arguments are either not serializable or just undesirably large to store in redux state.

For example, this was an issue in server-side rendering use case where the Express request object needed to be an argument to the action.